### PR TITLE
Migrate to bevy 0.13

### DIFF
--- a/examples-crate/Cargo.toml
+++ b/examples-crate/Cargo.toml
@@ -3,11 +3,37 @@ name = "block-mesh-examples"
 version = "0.1.0"
 edition = "2021"
 
-[dependencies]
-#bevy = { version = "0.11", default-features = false, features = ["bevy_winit", "bevy_render", "bevy_asset", "bevy_pbr",  "png", "x11"] }
-# Not sure why the above doesn't work, but we can't configure the StandardMaterial in the examples then
-bevy = { version = "0.11" }
+[dependencies.bevy]
+version = "0.13"
+default-features = false
+features = [
+    "bevy_asset",
+    "bevy_core_pipeline",
+    "bevy_pbr",
+    "bevy_render",
+    "bevy_winit",
+    "png",
+    "ktx2",
+    "tonemapping_luts",
+    "zstd",
+]
 
+[target.'cfg(target_os = "linux")'.dev-dependencies.bevy]
+version = "0.13"
+default-features = false
+features = [
+    "bevy_asset",
+    "bevy_core_pipeline",
+    "bevy_pbr",
+    "bevy_render",
+    "bevy_winit",
+    "png",
+    "ktx2",
+    "tonemapping_luts",
+    "x11",
+    "wayland",
+    "zstd",
+]
 
 [dependencies.block-mesh]
 path = ".."

--- a/examples-crate/Cargo.toml
+++ b/examples-crate/Cargo.toml
@@ -4,7 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-bevy = { version = "0.6", default-features = false, features = ["bevy_winit", "render", "png", "x11"] }
+#bevy = { version = "0.11", default-features = false, features = ["bevy_winit", "bevy_render", "bevy_asset", "bevy_pbr",  "png", "x11"] }
+# Not sure why the above doesn't work, but we can't configure the StandardMaterial in the examples then
+bevy = { version = "0.11" }
 
 
 [dependencies.block-mesh]

--- a/examples-crate/render/main.rs
+++ b/examples-crate/render/main.rs
@@ -1,3 +1,6 @@
+use bevy::pbr::wireframe::{WireframeConfig, WireframePlugin};
+use bevy::render::mesh::{Indices, VertexAttributeValues};
+use bevy::render::render_resource::PrimitiveTopology;
 use block_mesh::ilattice::glam::Vec3A;
 use block_mesh::ndshape::{ConstShape, ConstShape3u32};
 use block_mesh::{
@@ -6,25 +9,27 @@ use block_mesh::{
 };
 
 use bevy::{
-    pbr::wireframe::{WireframeConfig, WireframePlugin},
     prelude::*,
     render::{
-        mesh::{Indices, VertexAttributeValues},
-        options::WgpuOptions,
-        render_resource::{PrimitiveTopology, WgpuFeatures},
+        settings::{WgpuFeatures, WgpuSettings},
+        RenderPlugin,
     },
 };
 
 fn main() {
     App::new()
-        .insert_resource(WgpuOptions {
-            features: WgpuFeatures::POLYGON_MODE_LINE,
-            ..Default::default()
-        })
-        .insert_resource(Msaa { samples: 4 })
-        .add_plugins(DefaultPlugins)
-        .add_plugin(WireframePlugin)
-        .add_startup_system(setup.system())
+        .init_resource::<WireframeConfig>()
+        .insert_resource(Msaa::Sample4)
+        .add_plugins((
+            DefaultPlugins.set(RenderPlugin {
+                wgpu_settings: WgpuSettings {
+                    features: WgpuFeatures::POLYGON_MODE_LINE,
+                    ..Default::default()
+                },
+            }),
+            WireframePlugin,
+        ))
+        .add_systems(Startup, setup)
         .run();
 }
 
@@ -36,7 +41,7 @@ fn setup(
 ) {
     wireframe_config.global = true;
 
-    commands.spawn_bundle(PointLightBundle {
+    commands.spawn(PointLightBundle {
         transform: Transform::from_translation(Vec3::new(25.0, 25.0, 25.0)),
         point_light: PointLight {
             range: 200.0,
@@ -45,7 +50,7 @@ fn setup(
         },
         ..Default::default()
     });
-    commands.spawn_bundle(PerspectiveCameraBundle {
+    commands.spawn(Camera3dBundle {
         transform: Transform::from_translation(Vec3::new(50.0, 15.0, 50.0))
             .looking_at(Vec3::new(0.0, 0.0, 0.0), Vec3::Y),
         ..Default::default()
@@ -105,13 +110,16 @@ fn generate_simple_mesh(
     }
 
     let mut render_mesh = Mesh::new(PrimitiveTopology::TriangleList);
-    render_mesh.set_attribute(
-        "Vertex_Position",
+    render_mesh.insert_attribute(
+        Mesh::ATTRIBUTE_POSITION,
         VertexAttributeValues::Float32x3(positions),
     );
-    render_mesh.set_attribute("Vertex_Normal", VertexAttributeValues::Float32x3(normals));
-    render_mesh.set_attribute(
-        "Vertex_Uv",
+    render_mesh.insert_attribute(
+        Mesh::ATTRIBUTE_NORMAL,
+        VertexAttributeValues::Float32x3(normals),
+    );
+    render_mesh.insert_attribute(
+        Mesh::ATTRIBUTE_UV_0,
         VertexAttributeValues::Float32x2(vec![[0.0; 2]; num_vertices]),
     );
     render_mesh.set_indices(Some(Indices::U32(indices.clone())));
@@ -156,13 +164,16 @@ fn generate_greedy_mesh(
     }
 
     let mut render_mesh = Mesh::new(PrimitiveTopology::TriangleList);
-    render_mesh.set_attribute(
-        "Vertex_Position",
+    render_mesh.insert_attribute(
+        Mesh::ATTRIBUTE_POSITION,
         VertexAttributeValues::Float32x3(positions),
     );
-    render_mesh.set_attribute("Vertex_Normal", VertexAttributeValues::Float32x3(normals));
-    render_mesh.set_attribute(
-        "Vertex_Uv",
+    render_mesh.insert_attribute(
+        Mesh::ATTRIBUTE_NORMAL,
+        VertexAttributeValues::Float32x3(normals),
+    );
+    render_mesh.insert_attribute(
+        Mesh::ATTRIBUTE_UV_0,
         VertexAttributeValues::Float32x2(vec![[0.0; 2]; num_vertices]),
     );
     render_mesh.set_indices(Some(Indices::U32(indices.clone())));
@@ -176,12 +187,13 @@ fn spawn_pbr(
     mesh: Handle<Mesh>,
     transform: Transform,
 ) {
-    let mut material = StandardMaterial::from(Color::rgb(0.0, 0.0, 0.0));
+    let mut material = StandardMaterial::from(Color::BLACK);
     material.perceptual_roughness = 0.9;
+    let material = materials.add(material);
 
-    commands.spawn_bundle(PbrBundle {
+    commands.spawn(PbrBundle {
         mesh,
-        material: materials.add(material),
+        material,
         transform,
         ..Default::default()
     });

--- a/examples-crate/render/main.rs
+++ b/examples-crate/render/main.rs
@@ -1,6 +1,8 @@
 use bevy::pbr::wireframe::{WireframeConfig, WireframePlugin};
 use bevy::render::mesh::{Indices, VertexAttributeValues};
+use bevy::render::render_asset::RenderAssetUsages;
 use bevy::render::render_resource::PrimitiveTopology;
+use bevy::render::settings::RenderCreation;
 use block_mesh::ilattice::glam::Vec3A;
 use block_mesh::ndshape::{ConstShape, ConstShape3u32};
 use block_mesh::{
@@ -22,10 +24,11 @@ fn main() {
         .insert_resource(Msaa::Sample4)
         .add_plugins((
             DefaultPlugins.set(RenderPlugin {
-                wgpu_settings: WgpuSettings {
+                render_creation: RenderCreation::Automatic(WgpuSettings {
                     features: WgpuFeatures::POLYGON_MODE_LINE,
                     ..Default::default()
-                },
+                }),
+                ..default()
             }),
             WireframePlugin,
         ))
@@ -45,7 +48,7 @@ fn setup(
         transform: Transform::from_translation(Vec3::new(25.0, 25.0, 25.0)),
         point_light: PointLight {
             range: 200.0,
-            intensity: 8000.0,
+            //intensity: 8000.0,
             ..Default::default()
         },
         ..Default::default()
@@ -71,6 +74,11 @@ fn setup(
         greedy_sphere_mesh,
         Transform::from_translation(Vec3::new(-16.0, -16.0, 8.0)),
     );
+
+    commands.insert_resource(AmbientLight {
+        color: Color::WHITE,
+        brightness: light_consts::lux::OVERCAST_DAY,
+    });
 }
 
 fn generate_simple_mesh(
@@ -109,7 +117,10 @@ fn generate_simple_mesh(
         }
     }
 
-    let mut render_mesh = Mesh::new(PrimitiveTopology::TriangleList);
+    let mut render_mesh = Mesh::new(
+        PrimitiveTopology::TriangleList,
+        RenderAssetUsages::RENDER_WORLD,
+    );
     render_mesh.insert_attribute(
         Mesh::ATTRIBUTE_POSITION,
         VertexAttributeValues::Float32x3(positions),
@@ -122,7 +133,7 @@ fn generate_simple_mesh(
         Mesh::ATTRIBUTE_UV_0,
         VertexAttributeValues::Float32x2(vec![[0.0; 2]; num_vertices]),
     );
-    render_mesh.set_indices(Some(Indices::U32(indices.clone())));
+    render_mesh.insert_indices(Indices::U32(indices.clone()));
 
     meshes.add(render_mesh)
 }
@@ -163,7 +174,10 @@ fn generate_greedy_mesh(
         }
     }
 
-    let mut render_mesh = Mesh::new(PrimitiveTopology::TriangleList);
+    let mut render_mesh = Mesh::new(
+        PrimitiveTopology::TriangleList,
+        RenderAssetUsages::RENDER_WORLD,
+    );
     render_mesh.insert_attribute(
         Mesh::ATTRIBUTE_POSITION,
         VertexAttributeValues::Float32x3(positions),
@@ -176,7 +190,7 @@ fn generate_greedy_mesh(
         Mesh::ATTRIBUTE_UV_0,
         VertexAttributeValues::Float32x2(vec![[0.0; 2]; num_vertices]),
     );
-    render_mesh.set_indices(Some(Indices::U32(indices.clone())));
+    render_mesh.insert_indices(Indices::U32(indices.clone()));
 
     meshes.add(render_mesh)
 }

--- a/examples-crate/uv_mapping/main.rs
+++ b/examples-crate/uv_mapping/main.rs
@@ -2,30 +2,35 @@ use bevy::asset::LoadState;
 use bevy::prelude::*;
 use bevy::render::mesh::Indices;
 use bevy::render::render_resource::{AddressMode, PrimitiveTopology, SamplerDescriptor};
+use bevy::render::texture::ImageSampler;
 use block_mesh::ndshape::{ConstShape, ConstShape3u32};
 use block_mesh::{
     greedy_quads, GreedyQuadsBuffer, MergeVoxel, Voxel, VoxelVisibility, RIGHT_HANDED_Y_UP_CONFIG,
 };
 
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[derive(Default, Clone, Copy, Debug, Eq, Hash, PartialEq, States)]
 enum AppState {
+    #[default]
     Loading,
     Run,
 }
 
 const UV_SCALE: f32 = 1.0 / 16.0;
 
+#[derive(Resource)]
 struct Loading(Handle<Image>);
 
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .insert_resource(State::new(AppState::Loading))
-        .add_state(AppState::Loading)
-        .add_system_set(SystemSet::on_enter(AppState::Loading).with_system(load_assets))
-        .add_system_set(SystemSet::on_update(AppState::Loading).with_system(check_loaded))
-        .add_system_set(SystemSet::on_enter(AppState::Run).with_system(setup))
-        .add_system_set(SystemSet::on_update(AppState::Run).with_system(camera_rotation_system))
+        .add_state::<AppState>()
+        .add_systems(OnEnter(AppState::Loading), load_assets)
+        .add_systems(Update, check_loaded.run_if(in_state(AppState::Loading)))
+        .add_systems(OnEnter(AppState::Run), setup)
+        .add_systems(
+            Update,
+            camera_rotation_system.run_if(in_state(AppState::Run)),
+        )
         .run();
 }
 
@@ -37,13 +42,13 @@ fn load_assets(mut commands: Commands, asset_server: Res<AssetServer>) {
 
 /// Make sure that our texture is loaded so we can change some settings on it later
 fn check_loaded(
-    mut state: ResMut<State<AppState>>,
+    mut next_state: ResMut<NextState<AppState>>,
     handle: Res<Loading>,
     asset_server: Res<AssetServer>,
 ) {
     debug!("check loaded");
     if let LoadState::Loaded = asset_server.get_load_state(&handle.0) {
-        state.set(AppState::Run).unwrap();
+        next_state.set(AppState::Run);
     }
 }
 
@@ -82,14 +87,14 @@ fn setup(
     mut textures: ResMut<Assets<Image>>,
 ) {
     debug!("setup");
-    let mut texture = textures.get_mut(&texture_handle.0).unwrap();
+    let texture = textures.get_mut(&texture_handle.0).unwrap();
 
     // Set the texture to tile over the entire quad
-    texture.sampler_descriptor = SamplerDescriptor {
+    texture.sampler_descriptor = ImageSampler::Descriptor(SamplerDescriptor {
         address_mode_u: AddressMode::Repeat,
         address_mode_v: AddressMode::Repeat,
         ..Default::default()
-    };
+    });
 
     type SampleShape = ConstShape3u32<22, 22, 22>;
 
@@ -142,19 +147,19 @@ fn setup(
         }
     }
 
-    render_mesh.set_attribute(Mesh::ATTRIBUTE_POSITION, positions);
-    render_mesh.set_attribute(Mesh::ATTRIBUTE_NORMAL, normals);
-    render_mesh.set_attribute(Mesh::ATTRIBUTE_UV_0, tex_coords);
+    render_mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, positions);
+    render_mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, normals);
+    render_mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, tex_coords);
     render_mesh.set_indices(Some(Indices::U32(indices)));
 
-    commands.spawn_bundle(PbrBundle {
+    commands.spawn(PbrBundle {
         mesh: meshes.add(render_mesh),
         material: materials.add(texture_handle.0.clone().into()),
         transform: Transform::from_translation(Vec3::splat(-10.0)),
         ..Default::default()
     });
 
-    commands.spawn_bundle(PointLightBundle {
+    commands.spawn(PointLightBundle {
         transform: Transform::from_translation(Vec3::new(0.0, 50.0, 50.0)),
         point_light: PointLight {
             range: 200.0,
@@ -163,13 +168,12 @@ fn setup(
         },
         ..Default::default()
     });
-    let camera = commands
-        .spawn_bundle(PerspectiveCameraBundle::default())
-        .id();
+    let camera = commands.spawn(Camera3dBundle::default()).id();
 
     commands.insert_resource(CameraRotationState::new(camera));
 }
 
+#[derive(Resource)]
 struct CameraRotationState {
     camera: Entity,
 }
@@ -185,7 +189,7 @@ fn camera_rotation_system(
     time: Res<Time>,
     mut transforms: Query<&mut Transform>,
 ) {
-    let t = 0.3 * time.seconds_since_startup() as f32;
+    let t = 0.3 * time.elapsed_seconds();
 
     let target = Vec3::new(0.0, 0.0, 0.0);
     let height = 30.0 * (2.0 * t).sin();
@@ -193,7 +197,7 @@ fn camera_rotation_system(
     let x = radius * t.cos();
     let z = radius * t.sin();
     let eye = Vec3::new(x, height, z);
-    let new_transform = Mat4::face_toward(eye, target, Vec3::Y);
+    let new_transform = Mat4::look_at_rh(eye, target, Vec3::Y);
 
     let mut cam_tfm = transforms.get_mut(state.camera).unwrap();
     *cam_tfm = Transform::from_matrix(new_transform);


### PR DESCRIPTION
Hello!

Two problems with the migration:

1) I can't find the correct bevy feature combination to make it work with minimal features. As you can see in the Cargo.toml I tried and actually tried a lot of combinations, but without all of bevy I couldn't get the StandardMaterial to work and it was pink instead of black

2) I can't get the uv_mapping example to work (no git lfs problem, I have the texture), it simple doesn't appear.

Still wanted to open this, because maybe it's useful for someone and maybe someone will jump in to fix the problems mentioned