### PR TITLE
Allow the voxel that produced an UnorientedUnitQuad to be preserved

### DIFF
--- a/examples-crate/Cargo.toml
+++ b/examples-crate/Cargo.toml
@@ -1,10 +1,11 @@
+[workspace]
 [package]
 name = "block-mesh-examples"
 version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-bevy = { version = "0.6", default-features = false, features = ["bevy_winit", "render", "png", "x11"] }
+bevy = { version = "0.6", features = ["bevy_winit", "render", "png", "x11"] }
 
 
 [dependencies.block-mesh]

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,16 +1,24 @@
 use crate::{UnorientedQuad, UnorientedUnitQuad};
 
 #[derive(Default)]
-pub struct QuadBuffer {
+pub struct QuadBuffer<V: Copy> {
     /// A group of quads for each block face. We rely on [`OrientedBlockFace`]
     /// metadata to interpret them.
-    pub groups: [Vec<UnorientedQuad>; 6],
+    pub groups: [Vec<UnorientedQuad<V>>; 6],
 }
 
-impl QuadBuffer {
+impl<V: Copy> QuadBuffer<V> {
     pub fn new() -> Self {
-        const EMPTY: Vec<UnorientedQuad> = Vec::new();
-        Self { groups: [EMPTY; 6] }
+        Self {
+            groups: [
+                Vec::<UnorientedQuad<V>>::new(),
+                Vec::<UnorientedQuad<V>>::new(),
+                Vec::<UnorientedQuad<V>>::new(),
+                Vec::<UnorientedQuad<V>>::new(),
+                Vec::<UnorientedQuad<V>>::new(),
+                Vec::<UnorientedQuad<V>>::new(),
+            ],
+        }
     }
 
     pub fn reset(&mut self) {
@@ -30,20 +38,28 @@ impl QuadBuffer {
 }
 
 #[derive(Default)]
-pub struct UnitQuadBuffer {
+pub struct UnitQuadBuffer<V> {
     /// A group of quads for each block face. We rely on [`OrientedBlockFace`]
     /// metadata to interpret them.
     ///
     /// When using these values for materials and lighting, you can access them
     /// using either the quad's minimum voxel coordinates or the vertex
     /// coordinates given by [`OrientedBlockFace::quad_corners`].
-    pub groups: [Vec<UnorientedUnitQuad>; 6],
+    pub groups: [Vec<UnorientedUnitQuad<V>>; 6],
 }
 
-impl UnitQuadBuffer {
+impl<V: Copy> UnitQuadBuffer<V> {
     pub fn new() -> Self {
-        const EMPTY: Vec<UnorientedUnitQuad> = Vec::new();
-        Self { groups: [EMPTY; 6] }
+        Self {
+            groups: [
+                Vec::<UnorientedUnitQuad<V>>::new(),
+                Vec::<UnorientedUnitQuad<V>>::new(),
+                Vec::<UnorientedUnitQuad<V>>::new(),
+                Vec::<UnorientedUnitQuad<V>>::new(),
+                Vec::<UnorientedUnitQuad<V>>::new(),
+                Vec::<UnorientedUnitQuad<V>>::new(),
+            ],
+        }
     }
 
     /// Clears the buffer.

--- a/src/geometry/face.rs
+++ b/src/geometry/face.rs
@@ -1,6 +1,6 @@
-use crate::{Axis, AxisPermutation, SignedAxis, UnorientedQuad};
-
 use ilattice::glam::{IVec3, UVec3};
+
+use crate::{Axis, AxisPermutation, SignedAxis, UnorientedQuad};
 
 /// Metadata that's used to aid in the geometric calculations for one of the 6 possible cube faces.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -39,12 +39,12 @@ impl OrientedBlockFace {
             AxisPermutation::even_with_normal_axis(normal.unsigned_axis()),
         )
     }
-    
+
     #[inline]
     pub fn n_sign(&self) -> i32 {
         self.n_sign
     }
-    
+
     #[inline]
     pub fn permutation(&self) -> AxisPermutation {
         self.permutation
@@ -73,7 +73,7 @@ impl OrientedBlockFace {
     /// Note that this is natural when UV coordinates have (0,0) at the bottom
     /// left, but when (0,0) is at the top left, V must be flipped.
     #[inline]
-    pub fn quad_corners(&self, quad: &UnorientedQuad) -> [UVec3; 4] {
+    pub fn quad_corners<V: Copy>(&self, quad: &UnorientedQuad<V>) -> [UVec3; 4] {
         let w_vec = self.u * quad.width;
         let h_vec = self.v * quad.height;
 
@@ -90,7 +90,11 @@ impl OrientedBlockFace {
     }
 
     #[inline]
-    pub fn quad_mesh_positions(&self, quad: &UnorientedQuad, voxel_size: f32) -> [[f32; 3]; 4] {
+    pub fn quad_mesh_positions<V: Copy>(
+        &self,
+        quad: &UnorientedQuad<V>,
+        voxel_size: f32,
+    ) -> [[f32; 3]; 4] {
         self.quad_corners(quad)
             .map(|c| (voxel_size * c.as_vec3()).to_array())
     }
@@ -127,11 +131,11 @@ impl OrientedBlockFace {
     /// If you need to use a texture atlas, you must calculate your own
     /// coordinates from the `Quad`.
     #[inline]
-    pub fn tex_coords(
+    pub fn tex_coords<V: Copy>(
         &self,
         u_flip_face: Axis,
         flip_v: bool,
-        quad: &UnorientedQuad,
+        quad: &UnorientedQuad<V>,
     ) -> [[f32; 2]; 4] {
         let face_normal_axis = self.permutation.axes()[0];
         let flip_u = if self.n_sign < 0 {

--- a/src/geometry/quad.rs
+++ b/src/geometry/quad.rs
@@ -5,22 +5,25 @@
 /// using either the quad's minimum voxel coordinates or the vertex coordinates
 /// given by `OrientedBlockFace::quad_corners`.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct UnorientedQuad {
+pub struct UnorientedQuad<V: Copy> {
     /// The minimum voxel in the quad.
     pub minimum: [u32; 3],
     /// Width of the quad.
     pub width: u32,
     /// Height of the quad.
     pub height: u32,
+    /// Voxel that produced it
+    pub voxel: V,
 }
 
-impl From<UnorientedUnitQuad> for UnorientedQuad {
+impl<V: Copy> From<UnorientedUnitQuad<V>> for UnorientedQuad<V> {
     #[inline]
-    fn from(unit: UnorientedUnitQuad) -> Self {
+    fn from(unit: UnorientedUnitQuad<V>) -> Self {
         Self {
             minimum: unit.minimum,
             width: 1,
             height: 1,
+            voxel: unit.voxel,
         }
     }
 }
@@ -29,7 +32,9 @@ impl From<UnorientedUnitQuad> for UnorientedQuad {
 /// orientation. To get the actual corners of the quad, combine with an
 /// [`OrientedBlockFace`].
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct UnorientedUnitQuad {
+pub struct UnorientedUnitQuad<V> {
     /// The minimum voxel in the quad.
     pub minimum: [u32; 3],
+    /// voxel it originates from
+    pub voxel: V,
 }


### PR DESCRIPTION
Basically what the title says. The objective behind this is to allow custom texture coords to be generated depending on the type/data of the original voxel